### PR TITLE
Fix for when using $TEMPLATE

### DIFF
--- a/library/dpkg_reconfigure
+++ b/library/dpkg_reconfigure
@@ -120,7 +120,7 @@ def enforce_state(module, params):
             item = re.findall(r"[^\s]+", answer)
             if len(item) > 1:
                  wanted_config[ item[0].strip() ] = ' '.join(item[1:])
-            else:
+            elif len(item) == 1:
                  wanted_config[ item[0].strip() ] = ''
 
     current_config = get_selections(module, params["pkg"])


### PR DESCRIPTION
Fix wrong handling of empty lines when using the $TEMPLATE macro.
