### PR TITLE
Work around debconf booleans in dpkg_reconfigure

### DIFF
--- a/library/dpkg_reconfigure
+++ b/library/dpkg_reconfigure
@@ -76,7 +76,12 @@ def get_selections(module, pkg):
         for answer in out.split('\n'):
             item = re.search('^[* ] ([^:]+): (.*)$', answer)
             if item:
-                selections[ item.group(1).strip() ] = item.group(2).strip()
+                value = item.group(2).strip()
+                if value == 'true':
+                    value = 'yes'
+                elif value == 'false':
+                    value = 'no'
+                selections[ item.group(1).strip() ] = value
         return selections
     else:
         module.fail_json(msg=err)
@@ -122,6 +127,11 @@ def enforce_state(module, params):
                  wanted_config[ item[0].strip() ] = ' '.join(item[1:])
             elif len(item) == 1:
                  wanted_config[ item[0].strip() ] = ''
+
+    for key in wanted_config:
+        value = wanted_config[key]
+        if isinstance(value, bool):
+            wanted_config[key] = 'yes' if value else 'no'
 
     current_config = get_selections(module, params["pkg"])
 


### PR DESCRIPTION
To enable Ubuntu unattended upgrades I use this Ansible task:

``` yaml
- name: Enable unattended security updates
  dpkg_reconfigure:
    pkg: unattended-upgrades
    answers:
      unattended-upgrades/enable_auto_updates: yes
```

This task will always show as changed.

I traced it to a problem with the way booleans handled: `debconf-show` uses `true` and `false`, while `dpkg-reconfigure` uses `yes` and `no`. Another problem is that in playbooks a plain `yes` or `no` is converted into a Python boolean.

This pull request fixes both problems.
