### PR TITLE
Sync with recent Ansible's run_command()

### DIFF
--- a/library/dpkg_reconfigure
+++ b/library/dpkg_reconfigure
@@ -102,7 +102,7 @@ def dpkg_reconfigure(module, pkg, wanted_config):
     cmd = [ 'EDITOR=%s DEBIAN_FRONTEND=editor' % outsock_path ]
     cmd.append(module.get_bin_path('dpkg-reconfigure', True))
     cmd.append(pkg)
-    rc, out, err = module.run_command(' '.join(cmd))
+    rc, out, err = module.run_command(' '.join(cmd), use_unsafe_shell=True)
     os.unlink(outsock_path)
 
     if rc == 0:


### PR DESCRIPTION
use_unsafe_shell=True argument needs to be passed as argument to run_command()
in latest Ansible versions when using complex shell commands such as commands
prefixed by environnement variables definition.
