### PR TITLE
dpkg_reconfigure: edit configuration files rather than replacing them

### DIFF
--- a/library/dpkg_reconfigure
+++ b/library/dpkg_reconfigure
@@ -88,9 +88,11 @@ def get_selections(module, pkg):
 
 
 def dpkg_reconfigure(module, pkg, wanted_config):
-    editor_script = [ '#!/bin/sh', 'cat > $1 <<EOF' ]
-    for answer in wanted_config:
-        editor_script.append('%s="%s"' % (answer, wanted_config[answer]))
+    editor_script = [ '#!/bin/sh', 'sed -i "$1" -f - <<EOF' ]
+    for question in wanted_config:
+        e_question = re.sub(r'([\\/&])', r'\\\1', question)
+        e_answer = re.sub(r'([\\/&])', r'\\\1', wanted_config[question])
+        editor_script.append('s/^\\(%s\\)\\s*=.*/\\1="%s"/' % (e_question, e_answer))
     editor_script.append('EOF')
 
     outfd, outsock_path = tempfile.mkstemp()


### PR DESCRIPTION
The dpkg_reconfigure module currently requires all questions to be answered rather than only the ones that need to be changed/asserted. (I believe this is the actual problem being reported in #9.) This changes the editor script so that it edits the configuration files presented by dpkg-reconfigure rather than trying to substitute its own.
